### PR TITLE
Add flexible Excel field mapping and improved price formatting

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -187,12 +187,7 @@ public class MainForm : Form
             pt.SelectPrinter(printerName);
             pt.StartPrint();
 
-            string get(string logical)
-            {
-                var header = headers.FirstOrDefault(h => string.Equals(map.GetLogicalByHeader(h), logical, StringComparison.OrdinalIgnoreCase));
-                if (header == null) return "";
-                return _currentRow!.Cells.TryGetValue(header, out var v) ? v?.ToString() ?? "" : "";
-            }
+            string get(string logical) => map.GetString(_currentRow!, logical);
 
             foreach (var row in rows)
             {

--- a/appsettings.labels.json
+++ b/appsettings.labels.json
@@ -43,10 +43,10 @@
       }
     ],
     "columnAliases": {
-      "artikelnummer": ["Artikel","Artikel-Nr", "ArtNr", "Artikelnummer"],
-      "text": ["Text", "Name", "Artikelname", "Bezeichnung"],
+      "artikelnummer": ["Artikel","Artikel-Nr", "ArtNr", "Artikelnummer", "Artikel N°"],
+      "text": ["Text", "Name", "Artikelname", "Bezeichnung", "Artikel"],
       "beschreibung": ["Kurzbeschreibung", "Kurzbeschrieb", "Beschreibung", "Desc"],
-      "preis": ["Preis", "Verkaufspreis 1", "Artikelpreis 1", "Artikelpreis 2", "VK", "Verkaufspreis"],
+      "preis": ["Artikelpreis 2", "Verkaufspreis", "Preis", "Verkaufspreis 1", "Artikelpreis 1", "VK"],
       "menge": ["VPE", "Menge", "Anzahl", "Qty", "Stück"],
       "ean": ["EAN", "EAN Code", "EAN-Code", "Barcode", "EAN13"]
     },


### PR DESCRIPTION
## Summary
- Allow resolving logical fields by alias order to support multiple Excel layouts
- Prefer `Artikelpreis 2` when present and format prices to two decimals
- Expand column aliases for article number, name, and pricing